### PR TITLE
Fixes from end2end testing

### DIFF
--- a/config/end2end.php
+++ b/config/end2end.php
@@ -2,4 +2,9 @@
 
 return [
     'api_url' => 'http://end2end--gateway.elife.internal',
+    'aws' => [
+        'credential_file' => true,
+        'queue_name' => 'recommendations--end2end',
+        'region' => 'us-east-1',
+    ],
 ];

--- a/config/end2end.php
+++ b/config/end2end.php
@@ -1,3 +1,5 @@
 <?php
 
-return [];
+return [
+    'api_url' => 'http://end2end--gateway.elife.internal',
+];

--- a/config/prod.php
+++ b/config/prod.php
@@ -1,3 +1,5 @@
 <?php
 
-return [];
+return [
+    'api_url' => 'http://prod--gateway.elife.internal',
+];

--- a/config/prod.php
+++ b/config/prod.php
@@ -2,4 +2,9 @@
 
 return [
     'api_url' => 'http://prod--gateway.elife.internal',
+    'aws' => [
+        'credential_file' => true,
+        'queue_name' => 'recommendations--prod',
+        'region' => 'us-east-1',
+    ],
 ];

--- a/src/Recommendations/Rule/Common/GetSdk.php
+++ b/src/Recommendations/Rule/Common/GetSdk.php
@@ -66,7 +66,7 @@ trait GetSdk
             case 'short-report':
             case 'tools-resources':
             // end of -- are these needed?
-                
+
             case 'article':
                 return $this->sdk->articles();
                 break;

--- a/src/Recommendations/Rule/Common/GetSdk.php
+++ b/src/Recommendations/Rule/Common/GetSdk.php
@@ -52,6 +52,7 @@ trait GetSdk
                 return $this->sdk->collections();
                 break;
 
+            // are these needed?
             case 'correction':
             case 'editorial':
             case 'feature':
@@ -64,6 +65,9 @@ trait GetSdk
             case 'replication-study':
             case 'short-report':
             case 'tools-resources':
+            // end of -- are these needed?
+                
+            case 'article':
                 return $this->sdk->articles();
                 break;
 

--- a/src/Recommendations/RuleModelRepository.php
+++ b/src/Recommendations/RuleModelRepository.php
@@ -107,7 +107,7 @@ class RuleModelRepository
     public function get(RuleModel $ruleModel)
     {
         $prepared = $this->db->prepare('SELECT Rules.rule_id FROM Rules WHERE Rules.id = ? AND Rules.type = ? LIMIT 1;');
-        $prepared->bindParam(1, $ruleModel->getId());
+        $prepared->bindValue(1, $ruleModel->getId());
         $prepared->bindValue(2, $ruleModel->getType());
         $prepared->execute();
 


### PR DESCRIPTION
- URLs need to be configured
- `article` is the key that the SDK is requested for
- `Notice` from incorrectly binding variables to PDOStatement

Is it normal that the code talks to the gateway when serving a request? It's a bad sign as we get to 4 hops (journal -> gateway -> recommendations -> gateway -> lax) to use this API