### PR TITLE
Do not override transform()

### DIFF
--- a/bin/ci-import
+++ b/bin/ci-import
@@ -6,7 +6,7 @@ if [ -z "$environment" ]; then
     exit 2;
 fi;
 
-expected_rules=14
+expected_rules=29
 
 # propagate SIGINT to waiting process
 trap 'kill -INT -$waitingPid' INT

--- a/src/Recommendations/Command/MysqlRepoQueueCommand.php
+++ b/src/Recommendations/Command/MysqlRepoQueueCommand.php
@@ -39,11 +39,6 @@ final class MysqlRepoQueueCommand extends QueueCommand
             ->addArgument('id', InputArgument::OPTIONAL, 'Identifier to distinguish workers from each other');
     }
 
-    public function transform(QueueItem $item)
-    {
-        return $this->transformer->transform($item);
-    }
-
     protected function process(InputInterface $input, QueueItem $model, $entity = null)
     {
         $type = method_exists($entity, 'getType') ? $entity->getType() : $model->getType();


### PR DESCRIPTION
transform() in the base class has useful `catch`es that capture things
like 404 and delete the item from the queue. Overriding it with this
simple version will reprocess the 404 messages forever (well 4 weeks
feels like forever).