### PR TITLE
External articles support

### DIFF
--- a/bin/ci-import
+++ b/bin/ci-import
@@ -6,7 +6,7 @@ if [ -z "$environment" ]; then
     exit 2;
 fi;
 
-expected_rules=29
+expected_rules=30
 
 # propagate SIGINT to waiting process
 trap 'kill -INT -$waitingPid' INT

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -4,4 +4,6 @@ set -e
 rm -f build/*.xml
 proofreader src/ tests/ web/
 vendor/bin/phpunit --log-junit build/phpunit.xml
+# the api-dummy is currently missing external articles in the related articles of its samples
+# they should be added, to get feeback in ci
 bin/ci-import ci

--- a/src/App/DefaultController.php
+++ b/src/App/DefaultController.php
@@ -72,6 +72,9 @@ final class DefaultController
         return $mediaType;
     }
 
+    // TODO: remove? It's not in the api-raml, we are not using it for testing
+    // and it doesn't work anymore.
+    // SQLSTATE[42S22]: Column not found: 1054 Unknown column 'R.published' in 'order clause'
     public function allAction(Request $request)
     {
         $page = $request->get('page', 1);

--- a/src/App/Kernel.php
+++ b/src/App/Kernel.php
@@ -275,6 +275,8 @@ final class Kernel implements MinimalKernel
                     new CollectionContents($app['rules.micro_sdk'], $app['rules.repository']),
                     /* 12 */
                     new PodcastEpisodeContents($app['rules.micro_sdk'], $app['rules.repository'])
+                    // new RelatedExternalArticleContents(...)
+                    //    using new RuleModel("{$input->getId()}-{$externalArticle->getIndex()}", 'podcast-episode-chapter', null, $synthetic=true)
                 ),
                 /* 13 */
                 new MostRecent($app['rules.repository'], $app['logger']),

--- a/src/App/Kernel.php
+++ b/src/App/Kernel.php
@@ -275,8 +275,6 @@ final class Kernel implements MinimalKernel
                     new CollectionContents($app['rules.micro_sdk'], $app['rules.repository']),
                     /* 12 */
                     new PodcastEpisodeContents($app['rules.micro_sdk'], $app['rules.repository'])
-                    // new RelatedExternalArticleContents(...)
-                    //    using new RuleModel("{$input->getId()}-{$externalArticle->getIndex()}", 'podcast-episode-chapter', null, $synthetic=true)
                 ),
                 /* 13 */
                 new MostRecent($app['rules.repository'], $app['logger']),

--- a/src/App/Kernel.php
+++ b/src/App/Kernel.php
@@ -402,7 +402,7 @@ final class Kernel implements MinimalKernel
         }
         // Cache.
         if ($app['config']['ttl'] > 0) {
-            $app->after([$this, 'cache'], 3);
+            $app->after([$this, 'cacheDirectives'], 3);
         }
         // Error handling.
         if (!$app['config']['debug']) {
@@ -494,7 +494,7 @@ final class Kernel implements MinimalKernel
         return $response;
     }
 
-    public function cache(Request $request, Response $response)
+    public function cacheDirectives(Request $request, Response $response)
     {
         if ($response instanceof PrivateResponse) {
             return $response;

--- a/src/Recommendations/Process/Hydration.php
+++ b/src/Recommendations/Process/Hydration.php
@@ -12,6 +12,7 @@ namespace eLife\Recommendations\Process;
 
 use Assert\Assertion;
 use eLife\ApiSdk\Model\ArticleVersion;
+use eLife\ApiSdk\Model\ExternalArticle;
 use eLife\ApiSdk\Model\HasSubjects;
 use eLife\ApiSdk\Model\PodcastEpisode;
 use eLife\ApiSdk\Model\PodcastEpisodeChapter;
@@ -73,14 +74,27 @@ class Hydration
         return new PodcastEpisodeChapterModel($episode, $chapter);
     }
 
+    public function getExternalArticleByOriginalArticleId($id): ExternalArticle
+    {
+        list($originalArticleId, $relatedIndex) = explode('-', $id);
+        $relatedIndex = (int) $relatedIndex;
+
+/** @var ExternalArticle $episode */
+        // TODO: this uses sdk but it should really go through SingleItemRepository (doesn't have a method for this) or in any case through a cache
+        $externalArticle = $this->sdk->getRelatedArticles($originalArticleId)[$relatedIndex];
+
+        return $externalArticle;
+    }
+
     public function hydrateOne(RuleModel $item)
     {
         if ($item->isSynthetic()) {
             switch ($item->getType()) {
                 case 'podcast-episode-chapter':
                     return $this->getPodcastEpisodeChapterById($item->getId());
+                case 'external-article':
+                    return $this->getExternalArticleByOriginalArticleId($item->getId());
             }
-            // we should add external articles here, using a $this->getExternalArticleById($item->getId()) method
         }
 
         return $this->repo->get($this->convertType($item->getType()), $item->getId());

--- a/src/Recommendations/Process/Hydration.php
+++ b/src/Recommendations/Process/Hydration.php
@@ -100,6 +100,7 @@ class Hydration
         return $this->repo->get($this->convertType($item->getType()), $item->getId());
     }
 
+    // TODO: delete after having extracted all knowledge. It's dead code
     public function extractRelatedFrom(RuleModel $model)
     {
         $model = $this->hydrateOne($model);

--- a/src/Recommendations/Process/Hydration.php
+++ b/src/Recommendations/Process/Hydration.php
@@ -80,6 +80,7 @@ class Hydration
                 case 'podcast-episode-chapter':
                     return $this->getPodcastEpisodeChapterById($item->getId());
             }
+            // we should add external articles here, using a $this->getExternalArticleById($item->getId()) method
         }
 
         return $this->repo->get($this->convertType($item->getType()), $item->getId());

--- a/src/Recommendations/Rule/BidirectionalRelationship.php
+++ b/src/Recommendations/Rule/BidirectionalRelationship.php
@@ -57,10 +57,11 @@ class BidirectionalRelationship implements Rule
      * Given a model (type + id) from SQS, calculate which entities need
      * relations added for the specific domain rule.
      *
-     * Return is an array of tuples containing an input and an on where `input`
-     * is the model to be added and `on` is the target node. In plain english
-     * given a podcast containing articles it would return an array where the
-     * podcast is every `input` and each article is the `output`.
+     * Return is an array of tuples containing an `input` and an `on` where
+     * `input` * is the model to be added and `on` is the target node.
+     * In plain english given an article related to other articles it would
+     * return an array * where the first is every `input` and each related
+     * article is the `output`.
      */
     public function resolveRelations(RuleModel $input): array
     {
@@ -95,6 +96,9 @@ class BidirectionalRelationship implements Rule
             })
             ->map(function (Article $article) use ($input) {
                 $id = $article->getId();
+                // we should probably ignore external articles here
+                // 1. when we ignore them, the API starts working for articles that contain them
+                // 2. we can add them to the relations in a separate Rule implementation, see Kernel changes
                 $type = $article instanceof ExternalArticleModel ? 'external-article' : $article->getType();
                 $date = $article instanceof ArticleVersion ? $article->getPublishedDate() : null;
                 $relationship = new ManyToManyRelationship($input, new RuleModel($article->getId(), $type, $date));

--- a/src/Recommendations/Rule/BidirectionalRelationship.php
+++ b/src/Recommendations/Rule/BidirectionalRelationship.php
@@ -86,6 +86,7 @@ class BidirectionalRelationship implements Rule
         }
         $this->debug($input, sprintf('Found (%d) related article(s)', $related->count()));
 
+        // we don't have access to this in map():
         $index = 0;
 
         return $related
@@ -101,10 +102,7 @@ class BidirectionalRelationship implements Rule
             })
             ->map(function (Article $article) use ($input, &$index) {
                 $id = $article->getId();
-                // we should probably ignore external articles here
-                // 1. when we ignore them, the API starts working for articles that contain them
-                // 2. we can add them to the relations in a separate Rule implementation, see Kernel changes
-                $type = $article instanceof ExternalArticleModel ? 'external-article' : $article->getType();
+                $type = $article->getType();
                 $date = $article instanceof ArticleVersion ? $article->getPublishedDate() : null;
                 if ($article instanceof ExternalArticleModel) {
                     $relationship = new ManyToManyRelationship($input, new RuleModel($input->getId().'-'.$index, $type, $date, $isSynthetic = true));

--- a/src/Recommendations/Rule/BidirectionalRelationship.php
+++ b/src/Recommendations/Rule/BidirectionalRelationship.php
@@ -16,6 +16,9 @@ use eLife\Recommendations\RuleModelRepository;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
+/**
+ * TODO: rename into RelatedArticles?
+ */
 class BidirectionalRelationship implements Rule
 {
     use PersistRule;

--- a/src/Recommendations/Rule/BidirectionalRelationship.php
+++ b/src/Recommendations/Rule/BidirectionalRelationship.php
@@ -86,9 +86,6 @@ class BidirectionalRelationship implements Rule
         }
         $this->debug($input, sprintf('Found (%d) related article(s)', $related->count()));
 
-        // we don't have access to this in map():
-        $index = 0;
-
         return $related
             ->filter(function ($item) use ($input) {
                 $isArticle = $item instanceof Article;
@@ -100,12 +97,12 @@ class BidirectionalRelationship implements Rule
 
                 return $isArticle;
             })
-            ->map(function (Article $article) use ($input, &$index) {
+            ->map(function (Article $article) use ($input) {
                 $id = $article->getId();
                 $type = $article->getType();
                 $date = $article instanceof ArticleVersion ? $article->getPublishedDate() : null;
                 if ($article instanceof ExternalArticleModel) {
-                    $relationship = new ManyToManyRelationship($input, new RuleModel($input->getId().'-'.$index, $type, $date, $isSynthetic = true));
+                    $relationship = new ManyToManyRelationship($input, new RuleModel($input->getId().'-'.$article->getUri(), $type, $date, $isSynthetic = true));
                 } else {
                     $relationship = new ManyToManyRelationship($input, new RuleModel($article->getId(), $type, $date));
                 }
@@ -113,7 +110,6 @@ class BidirectionalRelationship implements Rule
                     'relationship' => $relationship,
                     'article' => $article,
                 ]);
-                ++$index;
 
                 return $relationship;
             })

--- a/src/Recommendations/Rule/CollectionContents.php
+++ b/src/Recommendations/Rule/CollectionContents.php
@@ -57,6 +57,7 @@ final class CollectionContents implements Rule
             })
             ->map(function (Article $article) use ($input) {
                 $id = $article->getId();
+                // also this is strange, can collections contains external articles and is this the assumption being made here?
                 $type = $article instanceof ExternalArticle ? 'external-article' : $article->getType();
                 $date = $article instanceof ArticleVersion ? $article->getPublishedDate() : null;
                 $relationship = new ManyToManyRelationship(new RuleModel($id, $type, $date), $input);

--- a/src/Recommendations/Rule/CollectionContents.php
+++ b/src/Recommendations/Rule/CollectionContents.php
@@ -5,7 +5,6 @@ namespace eLife\Recommendations\Rule;
 use eLife\ApiSdk\Model\Article;
 use eLife\ApiSdk\Model\ArticleVersion;
 use eLife\ApiSdk\Model\Collection;
-use eLife\ApiSdk\Model\ExternalArticle;
 use eLife\Recommendations\Relationships\ManyToManyRelationship;
 use eLife\Recommendations\Rule;
 use eLife\Recommendations\Rule\Common\MicroSdk;
@@ -57,8 +56,7 @@ final class CollectionContents implements Rule
             })
             ->map(function (Article $article) use ($input) {
                 $id = $article->getId();
-                // also this is strange, can collections contains external articles and is this the assumption being made here?
-                $type = $article instanceof ExternalArticle ? 'external-article' : $article->getType();
+                $type = $article->getType();
                 $date = $article instanceof ArticleVersion ? $article->getPublishedDate() : null;
                 $relationship = new ManyToManyRelationship(new RuleModel($id, $type, $date), $input);
                 $this->debug($input, sprintf('Found article in content %s<%s>', $type, $id), [

--- a/src/Recommendations/Rule/PodcastEpisodeContents.php
+++ b/src/Recommendations/Rule/PodcastEpisodeContents.php
@@ -46,6 +46,7 @@ class PodcastEpisodeContents implements Rule
                 return $content instanceof Article;
             })->map(function (ArticleVersion $article) use ($input, $chapter) {
                 $id = $article->getId();
+                // are we sure this is needed? can podcast episodes link to external articles? I thought they were only present in /article/:id/related
                 $type = $article instanceof ExternalArticle ? 'external-article' : $article->getType();
                 $date = $article instanceof ArticleVersion ? $article->getPublishedDate() : null;
                 $relationship = new ManyToManyRelationship(

--- a/src/Recommendations/Rule/PodcastEpisodeContents.php
+++ b/src/Recommendations/Rule/PodcastEpisodeContents.php
@@ -4,7 +4,6 @@ namespace eLife\Recommendations\Rule;
 
 use eLife\ApiSdk\Model\Article;
 use eLife\ApiSdk\Model\ArticleVersion;
-use eLife\ApiSdk\Model\ExternalArticle;
 use eLife\ApiSdk\Model\PodcastEpisode;
 use eLife\Recommendations\Relationships\ManyToManyRelationship;
 use eLife\Recommendations\Rule;
@@ -46,8 +45,7 @@ class PodcastEpisodeContents implements Rule
                 return $content instanceof Article;
             })->map(function (ArticleVersion $article) use ($input, $chapter) {
                 $id = $article->getId();
-                // are we sure this is needed? can podcast episodes link to external articles? I thought they were only present in /article/:id/related
-                $type = $article instanceof ExternalArticle ? 'external-article' : $article->getType();
+                $type = $article->getType();
                 $date = $article instanceof ArticleVersion ? $article->getPublishedDate() : null;
                 $relationship = new ManyToManyRelationship(
                     new RuleModel($article->getId(), $type, $date),

--- a/src/Recommendations/RuleModel.php
+++ b/src/Recommendations/RuleModel.php
@@ -52,8 +52,12 @@ class RuleModel implements JsonSerializable
      * Synthetic check.
      *
      * This will return whether or not the item is retrievable from
-     * the API SDK. If it is synthetic, the data will have to be
-     * retrieved from another, local, data source.
+     * the locally cached API SDK, as it came through from the bus
+     * and was retrieved in background.
+     *
+     * If it is synthetic, the data will have to be retrieved from:
+     * - its own API SDK, but it will be a cache miss initially (e.g. subjects)
+     * - the API SDK of another type (e.g. podcast episode chapters or external articles)
      */
     public function isSynthetic(): bool
     {

--- a/src/Recommendations/RuleModel.php
+++ b/src/Recommendations/RuleModel.php
@@ -19,6 +19,7 @@ class RuleModel implements JsonSerializable
     private $isSynthetic;
     private $published;
 
+    // TODO: RuleModel::synthetic($id, $type, $published = null) for clarity
     public function __construct(string $id, string $type, DateTimeImmutable $published = null, bool $isSynthetic = false, string $rule_id = null)
     {
         $this->id = $id;

--- a/tests/src/Rule/BidirectionalRelationshipTest.php
+++ b/tests/src/Rule/BidirectionalRelationshipTest.php
@@ -4,6 +4,7 @@ namespace tests\eLife\Rule;
 
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Model\Article;
+use eLife\ApiSdk\Model\ExternalArticle;
 use eLife\Recommendations\Rule\BidirectionalRelationship;
 use eLife\Recommendations\RuleModel;
 use Psr\Log\NullLogger;
@@ -24,9 +25,7 @@ class BidirectionalRelationshipTest extends BaseRuleTest
             ->method('getRelatedArticles')
             ->willReturn(new ArraySequence([$article]));
 
-        $this->assertTrue(in_array($article->getType(), $mock->supports()));
-
-        $relations = $mock->resolveRelations(new RuleModel('2', 'blog-article'));
+        $relations = $mock->resolveRelations(new RuleModel('17044', 'research-article'));
         foreach ($relations as $relation) {
             $this->assertValidRelation($relation);
         }
@@ -34,6 +33,17 @@ class BidirectionalRelationshipTest extends BaseRuleTest
 
     public function getArticleData()
     {
-        return array_merge((new ArticlePoANormalizerTest())->normalizeProvider(), (new ArticleVoRNormalizerTest())->normalizeProvider());
+        return array_merge(
+            (new ArticlePoANormalizerTest())->normalizeProvider(),
+            (new ArticleVoRNormalizerTest())->normalizeProvider(),
+            [
+                'external' => [new ExternalArticle(
+                    'Discovery and Preclinical Validation of Drug Indications Using Compendia of Public Gene Expression Data',
+                    'Science Translational Medicine',
+                    'M Sirota at al',
+                    'https =>//doi.org/10.1126/scitranslmed.3001318'
+                )],
+            ]
+        );
     }
 }

--- a/tests/src/Web/ArticleRecommendationsTest.php
+++ b/tests/src/Web/ArticleRecommendationsTest.php
@@ -41,13 +41,13 @@ class ArticleRecommendationsTest extends WebTestCase
 
         $a8 = $this->addArticle('008', 'registered-report', [], (new DateTimeImmutable())->setDate(2017, 1, 7));
 
-        $this->addExternalArticle('008-0');
+        $this->addExternalArticle('008-http://www.example.com/008-0');
 
         $this->relateArticlesByIds('002', ['003', '004']);
         $this->relateArticlesByIds('003', ['002']);
         $this->relateArticlesByIds('004', ['002', '006']);
         $this->relateArticlesByIds('006', ['004']);
-        $this->relateArticlesByIds('008', ['008-0']);
+        $this->relateArticlesByIds('008', ['008-http://www.example.com/008-0']);
 
         $this->getRulesProcess()->import($a1['model']);
         $this->getRulesProcess()->import($a2['model']);

--- a/tests/src/Web/ArticleRecommendationsTest.php
+++ b/tests/src/Web/ArticleRecommendationsTest.php
@@ -41,13 +41,13 @@ class ArticleRecommendationsTest extends WebTestCase
 
         $a8 = $this->addArticle('008', 'registered-report', [], (new DateTimeImmutable())->setDate(2017, 1, 7));
 
-        $this->addExternalArticle('http://www.example.com/');
+        $this->addExternalArticle('008-0');
 
         $this->relateArticlesByIds('002', ['003', '004']);
         $this->relateArticlesByIds('003', ['002']);
         $this->relateArticlesByIds('004', ['002', '006']);
         $this->relateArticlesByIds('006', ['004']);
-        $this->relateArticlesByIds('008', ['external-'.sha1('http://www.example.com/')]);
+        $this->relateArticlesByIds('008', ['008-0']);
 
         $this->getRulesProcess()->import($a1['model']);
         $this->getRulesProcess()->import($a2['model']);
@@ -181,7 +181,7 @@ class ArticleRecommendationsTest extends WebTestCase
         $this->assertEquals(2, $json->total);
 
         $this->assertEquals('external-article', $json->items[0]->type);
-        $this->assertEquals('http://www.example.com/', $json->items[0]->uri);
+        $this->assertEquals('http://www.example.com/008-0', $json->items[0]->uri);
 
         $this->assertEquals('006', $json->items[1]->id);
         $this->assertEquals('research-article', $json->items[1]->type);

--- a/tests/src/Web/WebTestCase.php
+++ b/tests/src/Web/WebTestCase.php
@@ -127,14 +127,17 @@ abstract class WebTestCase extends SilexWebTestCase
         ];
     }
 
-    public function addExternalArticle(string $id)
+    public function addExternalArticle(string $compositeId)
     {
+        $this->assertTrue((bool) preg_match('/^(\d+)-(.+)$/', $compositeId, $matches));
+        $originalArticleId = $matches[1];
+        $uri = $matches[2];
         $builder = Builder::for(ExternalArticle::class);
         $article = $builder->create(ExternalArticle::class)
-            ->withUri('http://www.example.com/'.$id);
+            ->withUri($uri);
 
         $article = $article->__invoke();
-        $this->addDocument('external-article', $id, $article);
+        $this->addDocument('external-article', $compositeId, $article);
     }
 
     public function relateArticlesByIds($id, array $ids)

--- a/tests/src/Web/WebTestCase.php
+++ b/tests/src/Web/WebTestCase.php
@@ -7,8 +7,8 @@ use Doctrine\DBAL\Connection;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Model\ArticlePoA;
 use eLife\ApiSdk\Model\Collection;
-use eLife\ApiSdk\Model\File;
 use eLife\ApiSdk\Model\ExternalArticle;
+use eLife\ApiSdk\Model\File;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\PodcastEpisode;
@@ -127,14 +127,14 @@ abstract class WebTestCase extends SilexWebTestCase
         ];
     }
 
-    public function addExternalArticle(string $uri)
+    public function addExternalArticle(string $id)
     {
         $builder = Builder::for(ExternalArticle::class);
         $article = $builder->create(ExternalArticle::class)
-            ->withUri($uri);
+            ->withUri('http://www.example.com/'.$id);
 
         $article = $article->__invoke();
-        $this->addDocument('external-article', 'external-'.sha1($uri), $article);
+        $this->addDocument('external-article', $id, $article);
     }
 
     public function relateArticlesByIds($id, array $ids)


### PR DESCRIPTION
It looks like recommendations has been using a concept of `synthetic` rule models to deal with `podcast-episode-chapter` types, which are quite similar to `external-article` types as there is no independent API for them. They need to be looked up in the `podcast-episode` and `article-related` APIs respectively.

`podcast-episode-chapter` are stored like this:
```
mysql> SELECT * FROM Rules WHERE type='podcast-episode-chapter' LIMIT 10;
+--------------------------------------+------+-------------------------+-----------+-------------+
| rule_id                              | id   | type                    | published | isSynthetic |
+--------------------------------------+------+-------------------------+-----------+-------------+
| 0412a762-9eb4-47c2-bccf-f14f1faa125e | 5-5  | podcast-episode-chapter | NULL      |           1 |

+--------------------------------------+------+-------------------------+-----------+-------------+
10 rows in set (0.00 sec)
```
My comments around this code propose to do a similar storage for external articles, using the original article id and their index in the `/article/:id/related` list:
```
mysql> SELECT * FROM Rules WHERE type='external-article';                           
+--------------------------------------+---------+------------------+-----------+-------------+
| rule_id                              | id      | type             | published | isSynthetic |
+--------------------------------------+---------+------------------+-----------+-------------+
| 90a5aa45-51e5-4d10-8337-e950337fc997 | 09560-1 | external-article | NULL      |           1 |
+--------------------------------------+---------+------------------+-----------+-------------+
```

As it stands, this work with the latest api-dummy containing one external related article. There are some TODOs in the diff I would like to get feedback on.

The known limitation is that every external related article is an additional external call when composing the response (to `/articles/:id/related`). This could be cached, but it needs to be correctly invalidated so I would like to clean up and get this in production with real data first. Currently an article related to external articles produces a 500, so it's a slow 200 is a first improvement.