### PR TITLE
Various TODOs from external article integration

### DIFF
--- a/src/App/DefaultController.php
+++ b/src/App/DefaultController.php
@@ -105,8 +105,6 @@ final class DefaultController
 
         $this->logger->debug('Rule model', ['id' => $id, 'type' => $type]);
         $requestModel = $this->repo->getOne($id, $type);
-        // This is meant to be an optimisation, but due to lack of cache elsewhere it currently slows it down.
-        //$this->hydrator->extractRelatedFrom($requestModel);
         $recommendations = $this->rules->getRecommendations($requestModel);
         $items = $this->hydrator->hydrateAll($recommendations);
         $context = $this->createContext();

--- a/src/App/DefaultController.php
+++ b/src/App/DefaultController.php
@@ -72,28 +72,6 @@ final class DefaultController
         return $mediaType;
     }
 
-    // TODO: remove? It's not in the api-raml, we are not using it for testing
-    // and it doesn't work anymore.
-    // SQLSTATE[42S22]: Column not found: 1054 Unknown column 'R.published' in 'order clause'
-    public function allAction(Request $request)
-    {
-        $page = $request->get('page', 1);
-        $perPage = $request->get('per-page', 100);
-        $offset = ($page - 1) * $perPage;
-
-        $mediaType = $this->acceptableRequest($request);
-        $version = $mediaType->getVersion() || self::CURRENT_VERSION;
-        $recommendations = $this->repo->slice($offset, $perPage);
-        $items = $this->hydrator->hydrateAll($recommendations);
-        $context = $this->createContext();
-        $context->setVersion($version);
-        $json = $this->serializer->serialize(RecommendationsResponse::fromModels($items, count($items)), 'json', $context);
-
-        return new Response($json, 200, [
-            'Content-Type' => (string) (new MediaType(self::MEDIA_TYPE, $version)),
-        ]);
-    }
-
     public function indexAction(Request $request, string $type, string $id)
     {
         if ($type !== 'article') {

--- a/src/App/Kernel.php
+++ b/src/App/Kernel.php
@@ -32,13 +32,13 @@ use eLife\Recommendations\Process\Hydration;
 use eLife\Recommendations\Process\Rules;
 use eLife\Recommendations\RecommendationResultDiscriminator;
 use eLife\Recommendations\Response\PrivateResponse;
-use eLife\Recommendations\Rule\BidirectionalRelationship;
 use eLife\Recommendations\Rule\CollectionContents;
 use eLife\Recommendations\Rule\Common\MicroSdk;
 use eLife\Recommendations\Rule\MostRecent;
 use eLife\Recommendations\Rule\MostRecentWithSubject;
 use eLife\Recommendations\Rule\NormalizedPersistence;
 use eLife\Recommendations\Rule\PodcastEpisodeContents;
+use eLife\Recommendations\Rule\RelatedArticles;
 use eLife\Recommendations\RuleModelRepository;
 use GuzzleHttp\Client;
 use JMS\Serializer\EventDispatcher\EventDispatcher;
@@ -269,7 +269,7 @@ final class Kernel implements MinimalKernel
                 new NormalizedPersistence(
                     $app['rules.repository'],
                     /* 1 - 10 */
-                    new BidirectionalRelationship($app['rules.micro_sdk'], $app['rules.repository'], $app['logger']),
+                    new RelatedArticles($app['rules.micro_sdk'], $app['rules.repository'], $app['logger']),
                     /* 11 */
                     new CollectionContents($app['rules.micro_sdk'], $app['rules.repository']),
                     /* 12 */

--- a/src/App/Kernel.php
+++ b/src/App/Kernel.php
@@ -67,7 +67,6 @@ final class Kernel implements MinimalKernel
 
     public static $routes = [
         '/recommendations/{type}/{id}' => 'indexAction',
-        '/recommendations' => 'allAction',
         '/ping' => 'pingAction',
     ];
 

--- a/src/Recommendations/Process/Hydration.php
+++ b/src/Recommendations/Process/Hydration.php
@@ -12,9 +12,7 @@ namespace eLife\Recommendations\Process;
 
 use Assert\Assertion;
 use eLife\ApiSdk\Model\Article;
-use eLife\ApiSdk\Model\ArticleVersion;
 use eLife\ApiSdk\Model\ExternalArticle;
-use eLife\ApiSdk\Model\HasSubjects;
 use eLife\ApiSdk\Model\PodcastEpisode;
 use eLife\ApiSdk\Model\PodcastEpisodeChapter;
 use eLife\ApiSdk\Model\PodcastEpisodeChapterModel;
@@ -106,28 +104,6 @@ class Hydration
         }
 
         return $this->repo->get($this->convertType($item->getType()), $item->getId());
-    }
-
-    // TODO: delete after having extracted all knowledge. It's dead code
-    public function extractRelatedFrom(RuleModel $model)
-    {
-        $model = $this->hydrateOne($model);
-        if ($model instanceof HasSubjects) {
-            $this->cache['subjects'] = $this->cache['subjects'] ?? [];
-            /** @var $model ArticleVersion */
-            foreach ($model->getSubjects() as $subjected) {
-                $this->cache['subjects'][$subjected->getId()] = $subjected;
-            }
-        }
-
-        if ($model instanceof ArticleVersion) {
-            $this->cache['related-article'] = $this->cache['related-article'] ?? [];
-            /** @var $model ArticleVersion */
-            foreach ($this->sdk->getRelatedArticles($model->getId()) as $relatedArticle) {
-                /* @var $relatedArticle ArticleVersion */
-                $this->cache[$relatedArticle->getType()][$relatedArticle->getId()] = $relatedArticle;
-            }
-        }
     }
 
     /**

--- a/src/Recommendations/Process/Hydration.php
+++ b/src/Recommendations/Process/Hydration.php
@@ -81,13 +81,13 @@ class Hydration
         if (!preg_match('/^(\d+)-(.+)$/', $id, $matches)) {
             throw new InvalidArgumentException("Not well-formed composite id of external article: $id");
         }
-        list(, $originalArticleId, $relatedIndex) = $matches;
+        list(, $originalArticleId, $externalArticleUri) = $matches;
 
         // TODO: this uses sdk but it should really go through SingleItemRepository (doesn't have a method for this) or in any case through a cache
         $externalArticle = $this->sdk
             ->getRelatedArticles($originalArticleId)
-            ->filter(function (Article $relatedArticle) use ($relatedIndex) {
-                return $relatedArticle instanceof ExternalArticle && $relatedArticle->getUri() === $relatedIndex;
+            ->filter(function (Article $relatedArticle) use ($externalArticleUri) {
+                return $relatedArticle instanceof ExternalArticle && $relatedArticle->getUri() === $externalArticleUri;
             })
             ->toArray()[0] ?? null;
 

--- a/src/Recommendations/Rule/BidirectionalRelationship.php
+++ b/src/Recommendations/Rule/BidirectionalRelationship.php
@@ -4,7 +4,6 @@ namespace eLife\Recommendations\Rule;
 
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Article;
-use eLife\ApiSdk\Model\ArticleVersion;
 use eLife\ApiSdk\Model\ExternalArticle as ExternalArticleModel;
 use eLife\Recommendations\Relationships\ManyToManyRelationship;
 use eLife\Recommendations\Rule;
@@ -100,10 +99,10 @@ class BidirectionalRelationship implements Rule
             ->map(function (Article $article) use ($input) {
                 $id = $article->getId();
                 $type = $article->getType();
-                $date = $article instanceof ArticleVersion ? $article->getPublishedDate() : null;
                 if ($article instanceof ExternalArticleModel) {
-                    $relationship = new ManyToManyRelationship($input, new RuleModel($input->getId().'-'.$article->getUri(), $type, $date, $isSynthetic = true));
+                    $relationship = new ManyToManyRelationship($input, RuleModel::synthetic($input->getId().'-'.$article->getUri(), $type));
                 } else {
+                    $date = $article->getPublishedDate();
                     $relationship = new ManyToManyRelationship($input, new RuleModel($article->getId(), $type, $date));
                 }
                 $this->debug($input, sprintf('Found related article %s<%s>', $type, $id), [

--- a/src/Recommendations/Rule/MostRecentWithSubject.php
+++ b/src/Recommendations/Rule/MostRecentWithSubject.php
@@ -96,7 +96,7 @@ class MostRecentWithSubject implements Rule
 
         $relations = $subjects
             ->map(function (Subject $subject) use ($input) {
-                $relation = new ManyToManyRelationship($input, new RuleModel($subject->getId(), 'subject', null, true));
+                $relation = new ManyToManyRelationship($input, RuleModel::synthetic($subject->getId(), 'subject'));
                 $this->debug($input, 'Adding relation for subject', [
                     'relation' => $relation,
                 ]);

--- a/src/Recommendations/Rule/PodcastEpisodeContents.php
+++ b/src/Recommendations/Rule/PodcastEpisodeContents.php
@@ -49,7 +49,7 @@ class PodcastEpisodeContents implements Rule
                 $date = $article instanceof ArticleVersion ? $article->getPublishedDate() : null;
                 $relationship = new ManyToManyRelationship(
                     new RuleModel($article->getId(), $type, $date),
-                    new RuleModel("{$input->getId()}-{$chapter->getNumber()}", 'podcast-episode-chapter', null, true)
+                    RuleModel::synthetic("{$input->getId()}-{$chapter->getNumber()}", 'podcast-episode-chapter')
                 );
                 $this->debug(
                     $input,

--- a/src/Recommendations/Rule/RelatedArticles.php
+++ b/src/Recommendations/Rule/RelatedArticles.php
@@ -15,10 +15,7 @@ use eLife\Recommendations\RuleModelRepository;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
-/**
- * TODO: rename into RelatedArticles?
- */
-class BidirectionalRelationship implements Rule
+class RelatedArticles implements Rule
 {
     use PersistRule;
     use RepoRelations;
@@ -67,6 +64,7 @@ class BidirectionalRelationship implements Rule
      */
     public function resolveRelations(RuleModel $input): array
     {
+        error_log($input->getType());
         $this->debug($input, 'Looking for related articles');
         try {
             $related = $this->getRelatedArticles($input->getId());

--- a/src/Recommendations/RuleModel.php
+++ b/src/Recommendations/RuleModel.php
@@ -11,6 +11,7 @@ namespace eLife\Recommendations;
 use DateTimeImmutable;
 use JsonSerializable;
 
+/* TODO: final? */
 class RuleModel implements JsonSerializable
 {
     private $rule_id;
@@ -19,7 +20,11 @@ class RuleModel implements JsonSerializable
     private $isSynthetic;
     private $published;
 
-    // TODO: RuleModel::synthetic($id, $type, $published = null) for clarity
+    public static function synthetic(string $id, string $type)
+    {
+        return new static($id, $type, $published = null, $isSynthetic = true);
+    }
+
     public function __construct(string $id, string $type, DateTimeImmutable $published = null, bool $isSynthetic = false, string $rule_id = null)
     {
         $this->id = $id;

--- a/src/Recommendations/RuleModel.php
+++ b/src/Recommendations/RuleModel.php
@@ -11,8 +11,7 @@ namespace eLife\Recommendations;
 use DateTimeImmutable;
 use JsonSerializable;
 
-/* TODO: final? */
-class RuleModel implements JsonSerializable
+final class RuleModel implements JsonSerializable
 {
     private $rule_id;
     private $id;
@@ -22,7 +21,7 @@ class RuleModel implements JsonSerializable
 
     public static function synthetic(string $id, string $type)
     {
-        return new static($id, $type, $published = null, $isSynthetic = true);
+        return new self($id, $type, $published = null, $isSynthetic = true);
     }
 
     public function __construct(string $id, string $type, DateTimeImmutable $published = null, bool $isSynthetic = false, string $rule_id = null)

--- a/tests/src/Rule/RelatedArticlesTest.php
+++ b/tests/src/Rule/RelatedArticlesTest.php
@@ -5,21 +5,21 @@ namespace tests\eLife\Rule;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Model\Article;
 use eLife\ApiSdk\Model\ExternalArticle;
-use eLife\Recommendations\Rule\BidirectionalRelationship;
+use eLife\Recommendations\Rule\RelatedArticles;
 use eLife\Recommendations\RuleModel;
 use Psr\Log\NullLogger;
 use test\eLife\ApiSdk\Serializer\ArticlePoANormalizerTest;
 use test\eLife\ApiSdk\Serializer\ArticleVoRNormalizerTest;
 
-class BidirectionalRelationshipTest extends BaseRuleTest
+class RelatedArticlesTest extends BaseRuleTest
 {
     /**
      * @dataProvider getArticleData
      */
     public function test(Article $article)
     {
-        /** @var BidirectionalRelationship | \PHPUnit_Framework_MockObject_MockObject $mock */
-        $mock = $this->createPartialMock(BidirectionalRelationship::class, ['getRelatedArticles']);
+        /** @var RelatedArticles | \PHPUnit_Framework_MockObject_MockObject $mock */
+        $mock = $this->createPartialMock(RelatedArticles::class, ['getRelatedArticles']);
         $mock->setLogger(new NullLogger());
         $mock->expects($this->exactly(1))
             ->method('getRelatedArticles')


### PR DESCRIPTION
- Renamed class to RelatedArticles

Logging which input arrive at this class, they are all articles and the
related articles (also either articles or external articles) are loaded on
those.
```
[19-May-2017 09:06:48 UTC] insight
[19-May-2017 09:06:48 UTC] research-article
[19-May-2017 09:06:48 UTC] research-article
[19-May-2017 09:06:48 UTC] research-advance
[19-May-2017 09:06:48 UTC] feature
[19-May-2017 09:06:48 UTC] research-article
[19-May-2017 09:06:48 UTC] research-article
[19-May-2017 09:06:48 UTC] editorial
[19-May-2017 09:06:48 UTC] research-article
[19-May-2017 09:06:48 UTC] research-article
```
-  Making ruleModel final
- Introducing RuleModel::synthetic() Factory Method
- Deleting not working / api
- Deleting dead code extractRelatedFrom()
- Better name for external article key