### PR TITLE
Podcast chapter fields standard name

### DIFF
--- a/src/Recommendations/Response/PodcastChapter.php
+++ b/src/Recommendations/Response/PodcastChapter.php
@@ -3,6 +3,7 @@
 namespace eLife\Recommendations\Response;
 
 use eLife\ApiSdk\Model\PodcastEpisodeChapter as ApiSdkPodcastEpisodeChapter;
+use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\Since;
 use JMS\Serializer\Annotation\Type;
 
@@ -23,6 +24,7 @@ class PodcastChapter
     /**
      * @Type("string")
      * @Since(version="1")
+     * @SerializedName("longTitle")
      */
     private $longTitle;
 
@@ -35,6 +37,7 @@ class PodcastChapter
     /**
      * @Type("string")
      * @Since(version="1")
+     * @SerializedName("impactStatement")
      */
     private $impactStatement;
 

--- a/tests/src/Web/ArticleRecommendationsTest.php
+++ b/tests/src/Web/ArticleRecommendationsTest.php
@@ -165,6 +165,7 @@ class ArticleRecommendationsTest extends WebTestCase
         $this->assertEquals('podcast-episode-chapter', $json->items[2]->type);
         $this->assertEquals('1', $json->items[2]->chapter->number);
         $this->assertEquals('2', $json->items[2]->episode->number);
+        $this->assertEquals('long title 1', $json->items[2]->chapter->longTitle);
 
         $this->assertEquals('005', $json->items[3]->id);
         $this->assertEquals('research-article', $json->items[3]->type);


### PR DESCRIPTION
Apparently the serializer defaults to make these field names snake_cased.