### PR TITLE
MostRecent tweaks

### DIFF
--- a/bin/ci-import
+++ b/bin/ci-import
@@ -7,6 +7,7 @@ if [ -z "$environment" ]; then
 fi;
 
 expected_rules=25
+expected_most_recent=7
 
 # propagate SIGINT to waiting process
 trap 'kill -INT -$waitingPid' INT
@@ -37,11 +38,27 @@ if [ ! "$waitingReturnCode" -eq "0" ]; then
     exit "$waitingReturnCode"
 fi
 
-# final verification
-total_rules=$(php bin/console query:count easy-read-rules --env=$environment)
-echo "Total rules in the index: $total_rules"
-if [ ! "$total_rules" -eq "$expected_rules" ]; then
-    echo "There should be exactly $expected_rules in the database"
+query_count () {
+    php bin/console query:count "$1" --env="$environment"
+}
+
+# final verifications
+## total rules
+total_rules=$(query_count easy-read-rules)
+echo "Total rules in the index (easy-read-rules): $total_rules"
+if [ "$total_rules" -eq "$expected_rules" ]; then
+    echo "✔ Correct number of rules in the index"
+else
+    echo "✘ There should be exactly $expected_rules in the database"
     exit 2
+fi
+
+most_recent=$(query_count latest-articles)
+echo "Total latest articles to use in MostRecent (latest-articles): $most_recent"
+if [ "$most_recent" -eq "$expected_most_recent" ]; then
+    echo "✔ Correct number of rules for MostRecent"
+else
+    echo "✘ There should be exactly $expected_most_recent for MostRecent to use. Run bin/queries/latest-articles to check"
+    exit 3
 fi
 

--- a/bin/queries/latest-articles.sql
+++ b/bin/queries/latest-articles.sql
@@ -1,4 +1,12 @@
 SELECT *
 FROM Rules
-WHERE Rules.type != 'subject' AND Rules.type != 'collection' AND Rules.type != 'podcast-episode'
+WHERE Rules.type IN (
+    'research-advance',
+    'research-article',
+    'replication-study',
+    'scientific-correspondence',
+    'short-report',
+    'tools-resources'
+)
+AND Rules.published IS NOT NULL
 ORDER BY Rules.published DESC

--- a/src/App/Kernel.php
+++ b/src/App/Kernel.php
@@ -278,9 +278,9 @@ final class Kernel implements MinimalKernel
                     new PodcastEpisodeContents($app['rules.micro_sdk'], $app['rules.repository'])
                 ),
                 /* 13 */
-                new MostRecent($app['rules.repository'], $app['logger']),
+                new MostRecentWithSubject($app['hydration.single_item_repository'], $app['rules.micro_sdk'], $app['rules.repository'], $app['logger']),
                 /* 14 */
-                new MostRecentWithSubject($app['hydration.single_item_repository'], $app['rules.micro_sdk'], $app['rules.repository'], $app['logger'])
+                new MostRecent($app['rules.repository'], $app['logger'])
             );
         };
 

--- a/src/Recommendations/Command/MysqlRepoQueueCommand.php
+++ b/src/Recommendations/Command/MysqlRepoQueueCommand.php
@@ -42,10 +42,13 @@ final class MysqlRepoQueueCommand extends QueueCommand
     protected function process(InputInterface $input, QueueItem $model, $entity = null)
     {
         $type = method_exists($entity, 'getType') ? $entity->getType() : $model->getType();
+        $published = method_exists($entity, 'getPublishedDate') ? $entity->getPublishedDate() : null;
         $this->logger->debug("{$this->getName()} Adding model to queue", [
             'type' => $type,
             'id' => $model->getId(),
+            'published' => $published,
         ]);
-        $this->rules->import(new RuleModel($model->getId(), $type));
+
+        $this->rules->import(new RuleModel($model->getId(), $type, $published));
     }
 }

--- a/src/Recommendations/Rule/MostRecent.php
+++ b/src/Recommendations/Rule/MostRecent.php
@@ -48,7 +48,8 @@ final class MostRecent implements Rule
             });
             if (
                 empty($intersection) &&
-                $item->equalTo($model) === false
+                $item->equalTo($model) === false &&
+                in_array($item->getType(), $this->supports())
             ) {
                 array_push($list, $item);
 
@@ -65,14 +66,8 @@ final class MostRecent implements Rule
     public function supports(): array
     {
         return [
-            'correction',
-            'editorial',
-            'feature',
-            'insight',
             'research-advance',
             'research-article',
-            'retraction',
-            'registered-report',
             'replication-study',
             'scientific-correspondence',
             'short-report',

--- a/tests/src/Web/ArticleRecommendationsTest.php
+++ b/tests/src/Web/ArticleRecommendationsTest.php
@@ -97,8 +97,8 @@ class ArticleRecommendationsTest extends WebTestCase
         $json = $this->getJsonResponse();
 
         $this->assertEquals(2, $json->total);
-        $this->assertEquals('006', $json->items[0]->id);
-        $this->assertEquals('002', $json->items[1]->id);
+        $this->assertEquals('002', $json->items[0]->id);
+        $this->assertEquals('006', $json->items[1]->id);
 
         $this->assertTrue(true);
     }
@@ -140,10 +140,10 @@ class ArticleRecommendationsTest extends WebTestCase
 //        $this->assertEquals('004', $json->items[1]->id);
 //        $this->assertEquals('insight', $json->items[1]->type);
 
-        $this->assertEquals('006', $json->items[2]->id);
+        $this->assertEquals('001', $json->items[2]->id);
         $this->assertEquals('research-article', $json->items[2]->type);
 
-        $this->assertEquals('001', $json->items[3]->id);
+        $this->assertEquals('006', $json->items[3]->id);
         $this->assertEquals('research-article', $json->items[3]->type);
 
         $this->assertTrue(true);


### PR DESCRIPTION
- MostRecent to only support some kinds of articles, they were already filtered but it is more clear to also express it in the class itself.
- MostRecentWithSubject should have priority over MostRecent
- MostRecent relies on `published` always being set over the items it uses, otherwise ordering is incorrect. We set the data and check in ci-import everything is well, by counting the relevant articles with this field set.