### PR TITLE
Send more requests concurrently

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -10,8 +10,10 @@ use eLife\ApiClient\HttpClient\Guzzle6HttpClient;
 use eLife\ApiClient\HttpClient\WarningCheckingHttpClient;
 use eLife\ApiSdk\ApiSdk;
 use eLife\ApiSdk\Collection\EmptySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Article;
+use eLife\ApiSdk\Model\ArticleHistory;
 use eLife\ApiSdk\Model\ExternalArticle;
 use eLife\ApiSdk\Model\HasPublishedDate;
 use eLife\ApiSdk\Model\Identifier;
@@ -32,6 +34,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Throwable;
+use function GuzzleHttp\Promise\all;
 
 $configFile = __DIR__.'/../config.php';
 
@@ -109,23 +112,6 @@ $app->get('/recommendations/{type}/{id}', function (Request $request, string $ty
 
     $article = $app['elife.api_sdk']->articles()->getHistory($id);
 
-    // Do this early as we have to then request each episode.
-    $podcastEpisodes = $app['elife.api_sdk']->podcastEpisodes()
-        ->containing(Identifier::article($id))
-        ->slice(0, 100);
-
-    try {
-        $article = $article->wait()->getVersions()[0];
-    } catch (BadResponse $e) {
-        switch ($e->getResponse()->getStatusCode()) {
-            case Response::HTTP_GONE:
-            case Response::HTTP_NOT_FOUND:
-                throw new HttpException($e->getResponse()->getStatusCode(), "$identifier does not exist", $e);
-        }
-
-        throw $e;
-    }
-
     $relations = $app['elife.api_sdk']->articles()
         ->getRelatedArticles($id)
         ->sort(function (Article $a, Article $b) {
@@ -156,14 +142,38 @@ $app->get('/recommendations/{type}/{id}', function (Request $request, string $ty
         });
 
     $collections = $app['elife.api_sdk']->collections()
-        ->containing($article->getIdentifier())
+        ->containing(Identifier::article($id))
         ->slice(0, 100);
 
-    $podcastEpisodeChapters = $podcastEpisodes
-        ->reduce(function (Sequence $chapters, PodcastEpisode $episode) use ($article) {
+    $mostRecent = $app['elife.api_sdk']->search()
+        ->forType('research-advance', 'research-article', 'scientific-correspondence', 'short-report', 'tools-resources', 'replication-study')
+        ->sortBy('date')
+        ->slice(0, 5);
+
+    $mostRecentWithSubject = new PromiseSequence($article
+        ->then(function (ArticleHistory $history) use ($app) {
+            $article = $history->getVersions()[0];
+
+            if ($article->getSubjects()->isEmpty()) {
+                return new EmptySequence();
+            }
+
+            $subject = $article->getSubjects()[0];
+
+            return $app['elife.api_sdk']->search()
+                ->forType('correction', 'editorial', 'feature', 'insight', 'research-advance', 'research-article', 'retraction', 'registered-report', 'replication-study', 'scientific-correspondence', 'short-report', 'tools-resources')
+                ->sortBy('date')
+                ->forSubject($subject->getId())
+                ->slice(0, 5);
+        }));
+
+    $podcastEpisodeChapters = $app['elife.api_sdk']->podcastEpisodes()
+        ->containing(Identifier::article($id))
+        ->slice(0, 100)
+        ->reduce(function (Sequence $chapters, PodcastEpisode $episode) use ($id) {
             foreach ($episode->getChapters() as $chapter) {
                 foreach ($chapter->getContent() as $content) {
-                    if ($article->getId() === $content->getId()) {
+                    if ($id === $content->getId()) {
                         $chapters = $chapters->append(new PodcastEpisodeChapterModel($episode, $chapter));
                         continue 2;
                     }
@@ -172,23 +182,6 @@ $app->get('/recommendations/{type}/{id}', function (Request $request, string $ty
 
             return $chapters;
         }, new EmptySequence());
-
-    if ($article->getSubjects()->notEmpty()) {
-        $subject = $article->getSubjects()[0];
-
-        $mostRecentWithSubject = $app['elife.api_sdk']->search()
-            ->forType('correction', 'editorial', 'feature', 'insight', 'research-advance', 'research-article', 'retraction', 'registered-report', 'replication-study', 'scientific-correspondence', 'short-report', 'tools-resources')
-            ->sortBy('date')
-            ->forSubject($subject->getId())
-            ->slice(0, 5);
-    } else {
-        $mostRecentWithSubject = new EmptySequence();
-    }
-
-    $mostRecent = $app['elife.api_sdk']->search()
-        ->forType('research-advance', 'research-article', 'scientific-correspondence', 'short-report', 'tools-resources', 'replication-study')
-        ->sortBy('date')
-        ->slice(0, 5);
 
     $recommendations = $relations;
 
@@ -215,6 +208,18 @@ $app->get('/recommendations/{type}/{id}', function (Request $request, string $ty
 
         return $recommendations;
     };
+
+    try {
+        all([$article, $relations, $collections, $podcastEpisodeChapters, $mostRecent, $mostRecentWithSubject])->wait();
+    } catch (BadResponse $e) {
+        switch ($e->getResponse()->getStatusCode()) {
+            case Response::HTTP_GONE:
+            case Response::HTTP_NOT_FOUND:
+                throw new HttpException($e->getResponse()->getStatusCode(), "$identifier does not exist", $e);
+        }
+
+        throw $e;
+    }
 
     $recommendations = $recommendations->append(...$collections);
     $recommendations = $recommendations->append(...$podcastEpisodeChapters);

--- a/test/RecommendationsTest.php
+++ b/test/RecommendationsTest.php
@@ -310,6 +310,10 @@ final class RecommendationsTest extends WebTestCase
         $client = static::createClient();
 
         $this->mockNotFound('articles/1234/versions', ['Accept' => 'application/vnd.elife.article-history+json; version=1']);
+        $this->mockRelatedArticlesCall('1234', []);
+        $this->mockCollectionsCall(0, [], 1, 100, [Identifier::article('1234')]);
+        $this->mockPodcastEpisodesCall(0, [], 1, 100, [Identifier::article('1234')]);
+        $this->mockSearchCall(0, [], 1, 5, ['research-advance', 'research-article', 'scientific-correspondence', 'short-report', 'tools-resources', 'replication-study']);
 
         $client->request('GET', '/recommendations/article/1234');
         $response = $client->getResponse();


### PR DESCRIPTION
`wait()`ing on the article for a subject results in 3 batches of requests being sent, which slows things down. This allows for the `$mostRecentWithSubject` request to happen as soon as `$article` has responded.

Getting the podcast episodes is still happening after the other requests have finished, so there's still room for improvement.