### PR TITLE
Updated elife/api-sdk to 690fd90: Only have a single Accept header

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -224,12 +224,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/api-sdk-php.git",
-                "reference": "18da533d8e1b93cddf7d99e4bb9e9a815510f8c0"
+                "reference": "690fd900374e2e5955216aaf81026c64d9f96032"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/api-sdk-php/zipball/18da533d8e1b93cddf7d99e4bb9e9a815510f8c0",
-                "reference": "18da533d8e1b93cddf7d99e4bb9e9a815510f8c0",
+                "url": "https://api.github.com/repos/elifesciences/api-sdk-php/zipball/690fd900374e2e5955216aaf81026c64d9f96032",
+                "reference": "690fd900374e2e5955216aaf81026c64d9f96032",
                 "shasum": ""
             },
             "require": {
@@ -264,7 +264,7 @@
                 "MIT"
             ],
             "description": "eLife Sciences API SDK",
-            "time": "2017-11-16T14:30:20+00:00"
+            "time": "2017-11-27T09:58:57+00:00"
         },
         {
             "name": "elife/content-negotiator",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies-recommendations-update-api-sdk-php/20/display/redirect which resulted in this pull request.