### PR TITLE
Updated elife/api-sdk to 05138ff: Bump version of collection and highlights list to support digests

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -225,12 +225,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/api-sdk-php.git",
-                "reference": "51c893b8d0b37345d082ced4eb9d7c64f35b5986"
+                "reference": "05138ffe3d2a50a9f68174f157e9dbd9f51e3f30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/api-sdk-php/zipball/51c893b8d0b37345d082ced4eb9d7c64f35b5986",
-                "reference": "51c893b8d0b37345d082ced4eb9d7c64f35b5986",
+                "url": "https://api.github.com/repos/elifesciences/api-sdk-php/zipball/05138ffe3d2a50a9f68174f157e9dbd9f51e3f30",
+                "reference": "05138ffe3d2a50a9f68174f157e9dbd9f51e3f30",
                 "shasum": ""
             },
             "require": {
@@ -266,7 +266,7 @@
                 "MIT"
             ],
             "description": "eLife Sciences API SDK",
-            "time": "2018-10-09T08:31:25+00:00"
+            "time": "2018-10-17T10:28:05+00:00"
         },
         {
             "name": "elife/content-negotiator",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/formula/job/dependencies-recommendations-update-api-sdk-php/12/display/redirect which resulted in this pull request.